### PR TITLE
Update README to include deps needed for Ubuntu 22.04

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,8 @@ A Wacom compatible tablet that works in native Linux applications. The tablet ne
 
 This uses the ``libxcb.so.1`` and ``libxcb-xinput.so.0`` libraries. On Debian/Ubuntu distributions, these can be obtained by installing the ``libxcb-xinput0`` package.
 
+On Debian/Ubuntu distributions, recommend to install requirements to biold via: ``sudo apt-get install libxcb-xinput0 libxcb-xinput-dev libwine-dev gcc-mingw-w64``.
+
 Installation
 ------------
 1. With Rebelle already installed, copy **BOTH** ``wintab32.dll`` and ``XWinTabHelper.dll.so`` into the installation directory (the one with the ``Rebelle 7.exe``).


### PR DESCRIPTION
Added deps I needed to install on Ubuntu 22.04. 

Figured it might help folks trying to build who are less experienced with tracking down deps for stuff.
